### PR TITLE
Add new repositories for CLUBB, COSP2, SILHS

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -14,23 +14,23 @@ required = True
 
 [cosp2]
 local_path = src/physics/cosp2/src
-protocol = svn
-repo_url = https://github.com/CFMIP/COSPv2.0/tags/
-tag = v2.1.4cesm/src
+protocol = git
+repo_url = https://github.com/daniele-peano/COSP2
+tag = cosp2_cmcc-cm_v01
 required = True
 
 [clubb]
 local_path = src/physics/clubb
-protocol = svn
-repo_url = https://github.com/larson-group/clubb_release/tags/
-tag = clubb_4ncar_20221129_59cb19f_20230330_branchtag/src/CLUBB_core
+protocol = git
+repo_url = https://github.com/daniele-peano/CLUBB
+tag = clubb_cmcc-cm_v01 
 required = True
 
 [silhs]
 local_path = src/physics/silhs
-protocol = svn
-repo_url = https://github.com/larson-group/clubb_release/tags/
-tag = clubb_4ncar_20221129_59cb19f_20230330_branchtag/src/SILHS
+protocol = git
+repo_url = https://github.com/daniele-peano/SILHS
+tag = silhs_cmcc-cm_v01
 required = True
 
 [pumas]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -15,21 +15,21 @@ required = True
 [cosp2]
 local_path = src/physics/cosp2/src
 protocol = git
-repo_url = https://github.com/daniele-peano/COSP2
+repo_url = https://github.com/CMCC-Foundation/COSP2
 tag = cosp2_cmcc-cm_v01
 required = True
 
 [clubb]
 local_path = src/physics/clubb
 protocol = git
-repo_url = https://github.com/daniele-peano/CLUBB
+repo_url = https://github.com/CMCC-Foundation/CLUBB
 tag = clubb_cmcc-cm_v01 
 required = True
 
 [silhs]
 local_path = src/physics/silhs
 protocol = git
-repo_url = https://github.com/daniele-peano/SILHS
+repo_url = https://github.com/CMCC-Foundation/SILHS
 tag = silhs_cmcc-cm_v01
 required = True
 


### PR DESCRIPTION
The previous SVN protocol used for CLUBB, COSP2, and SILHS is not working anymore.
For this reason, a separate version of those repositories has been created in the CMCC Foundation GitHub space to keep the same code version available.